### PR TITLE
Build documentation on Read The Docs with Python 3.11

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,16 +8,12 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
 # Optionally build your docs in additional formats such as PDF
 formats:
   - pdf
 
 python:
-  version: 3.8
+  version: "3.11"
   install:
     - requirements: docs/requirements.txt
     - {path: ., method: pip}


### PR DESCRIPTION
With Python 3.8 the scanners submodule fails because of modern type annotations.