### PR TITLE
Deprecate Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - "3.7"  # oldest Python supported by PSF
-        - "3.8"
+        - "3.8"  # oldest Python supported by PSF
         - "3.9"
         - "3.10"
         - "3.11"  # newest Python that is stable

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -214,7 +214,7 @@ package:
     tox -r -e docs
 
 #. Make sure to have a reliable |tox|_ installation that uses the correct
-   Python version (e.g., 3.7+). When in doubt you can run::
+   Python version (e.g., 3.8+). When in doubt you can run::
 
     tox --version
     # OR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ ignore = [
   "FBT",     # flake8-boolean-trap
   "T20",     # flake8-print
 ]
-# Always generate Python 3.7-compatible code
-target-version = "py37"
+# Always generate Python 3.8-compatible code
+target-version = "py38"
 
 src = ["src", "test"]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ classifiers =
 	Programming Language :: Python
 	Programming Language :: Python :: 3
 	Programming Language :: Python :: 3 :: Only
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
@@ -55,7 +54,7 @@ include_package_data = True
 package_dir =
     =src
 
-python_requires = >=3.7
+python_requires = >=3.8
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in
@@ -63,7 +62,6 @@ python_requires = >=3.7
 # For more information, check out https://semver.org/.
 install_requires =
     bleak>=0.19.0
-    importlib-metadata; python_version<"3.8"
 
 
 [options.packages.find]

--- a/src/bluetooth_clocks/__init__.py
+++ b/src/bluetooth_clocks/__init__.py
@@ -6,9 +6,9 @@ advertisements and has a device-independent API to set and get the time on them.
 from __future__ import annotations
 
 import logging
-import sys
 from abc import ABC, abstractmethod
 from importlib import import_module
+from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 from inspect import isclass
 from pathlib import Path
 from pkgutil import iter_modules
@@ -25,11 +25,6 @@ if TYPE_CHECKING:
     from bleak.backends.scanner import AdvertisementData
 
 from bluetooth_clocks.exceptions import TimeNotReadableError, UnsupportedDeviceError
-
-if sys.version_info[:2] >= (3, 8):
-    from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
-else:
-    from importlib_metadata import PackageNotFoundError, version  # pragma: no cover
 
 try:
     # Change here if project is renamed and does not equal the package name


### PR DESCRIPTION
Python 3.7 is EOL since 2023-06-27: https://devguide.python.org/versions/